### PR TITLE
Update smb.conf

### DIFF
--- a/thunar-shares-plugin-manjaro/smb.conf
+++ b/thunar-shares-plugin-manjaro/smb.conf
@@ -5,8 +5,11 @@
    max log size = 50
    security = user
    map to guest = Bad User
-   guest account = root
+   guest account = nobody
    usershare path = /var/lib/samba/usershare
    usershare max shares = 100
    usershare allow guests = yes
    usershare owner only = yes
+   group = sambashare
+   force create mode = 0070
+   force directory mode = 0070


### PR DESCRIPTION
"In the default install, every file and directory created by guests will have root as owner and group. This will prevent the actual computer user from editing/deleting the files created by a samba user. We set the “guest account” mapping to “nobody” and force every file created via samba to belong to the sambashare group and be editable by it."

See https://www.fomfus.com/articles/how-to-public-samba-shares-in-manjaro